### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.12"
     - name: Install tox
@@ -22,7 +22,7 @@ jobs:
       run: |-
         tox -e build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: python-package-distributions
         path: dist/
@@ -41,11 +41,11 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
       with:
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply-chain security hardening, replacing mutable tag references.

## Why

Mutable tags (e.g. `@v4`) can be moved by upstream maintainers or by an attacker who compromises an action repo. Pinning to a SHA ensures workflows always run exactly the reviewed code.

This follows GitHub's own security hardening guidance and improves our OpenSSF Scorecard rating.

## Changes

- Pinned all third-party and GitHub-maintained actions in workflow files to full 40-character commit SHAs
- Preserved original tag/branch versions in inline comments for readability
- Left already-pinned actions unchanged

## Testing

- Verified all `uses:` references in `.github/workflows/` now use immutable SHAs